### PR TITLE
[DATAVIC-156] Adjust ORM query to order by format in lowercase.

### DIFF
--- a/ckanext/datavic_iar_theme/helpers.py
+++ b/ckanext/datavic_iar_theme/helpers.py
@@ -1,8 +1,13 @@
 import ckan.model as model
 import ckan.plugins.toolkit as toolkit
+import logging
 
 from ckan.common import config
 from sqlalchemy import and_ as _and_
+from sqlalchemy.sql import func
+
+log = logging.getLogger(__name__)
+
 
 def organization_list():
     return toolkit.get_action('organization_list')({}, {'all_fields': True})
@@ -13,17 +18,25 @@ def search_form_group_list():
 
 
 def format_list(limit=100):
-    session = model.Session
+    resource_formats = []
+    try:
+        session = model.Session
 
-    query = (session.query(
-        model.Resource.format,)
-        .filter(_and_(
-            model.Resource.state == 'active',
-        ))
-        .group_by(model.Resource.format)
-        .order_by('format ASC'))
+        query = (session.query(
+            model.Resource.format,)
+            .filter(_and_(
+                model.Resource.state == 'active',
+            ))
+            .group_by(model.Resource.format)
+            .order_by(
+                func.lower(model.Resource.format)
+            ))
+        resource_formats = [resource.format for resource in query if not resource.format == '']
+    except Exception, e:
+        log.error(e.message)
 
-    return [resource.format for resource in query if not resource.format == '']
+    return resource_formats
+
 
 def get_parent_site_url():
     return config.get('ckan.parent_site_url', 'https://www.data.vic.gov.au')


### PR DESCRIPTION
This PR fixes an issue where resource formats were being displayed in the dataset search form out of order, due to being sorted alphabetically, but case sensitive.