### PR TITLE
[DATAVIC-144] Re-order CKAN dashboard tabs

### DIFF
--- a/ckanext/datavic_iar_theme/templates/user/dashboard.html
+++ b/ckanext/datavic_iar_theme/templates/user/dashboard.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+    {% block page_header %}
+      <header class="module-content page-header hug">
+        <div class="content_action">
+          {% link_for _('Edit settings'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}
+        </div>
+        <ul class="nav nav-tabs">
+          {{ h.build_nav_icon('user_dashboard_datasets', _('My Datasets')) }}
+          {{ h.build_nav_icon('user_dashboard_organizations', _('My Organizations')) }}
+          {{ h.build_nav_icon('user_dashboard_groups', _('My Groups')) }}
+          {{ h.build_nav_icon('user_dashboard', _('News feed')) }}
+        </ul>
+      </header>
+    {% endblock %}

--- a/ckanext/datavic_iar_theme/templates/user/snippets/login_form.html
+++ b/ckanext/datavic_iar_theme/templates/user/snippets/login_form.html
@@ -1,0 +1,31 @@
+{#
+Renders the login form.
+
+action        - The url that the form should be submitted to.
+error_summary - A tuple/list of form errors.
+
+Example:
+
+  {% snippet "user/snippets/login_form.html", action=c.login_handler, error_summary=error_summary %}
+
+#}
+{% import 'macros/form.html' as form %}
+
+{% set username_error = true if error_summary %}
+{% set password_error = true if error_summary %}
+
+<form action="{{ action }}?came_from=/dashboard/datasets" method="post" class="form-horizontal">
+  {{ form.errors(errors=error_summary) }}
+
+  {{ form.input('login', label=_("Username"), id='field-login', value="", error=username_error, classes=["control-medium"]) }}
+
+  {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"]) }}
+
+  {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000") }}
+
+  <div class="form-actions">
+    {% block login_button %}
+    <button class="btn btn-primary" type="submit">{{ _('Login') }}</button>
+    {% endblock %}
+  </div>
+</form>


### PR DESCRIPTION
This PR:
- Adds template override for dashboard tabs and adjusts order
- Adds template override for user login form, adding `came_from` parameter to form action to redirect user to `/dashboard/datasets` on login