### PR TITLE
[DATAVIC-177] Adjust dashboard links and remove login form `came_from…

### DIFF
--- a/ckanext/datavic_iar_theme/templates/header.html
+++ b/ckanext/datavic_iar_theme/templates/header.html
@@ -28,23 +28,6 @@
                   <span class="username">{{ c.userobj.display_name }}</span>
                 </a>
               </li>
-              {% set new_activities = h.new_activities() %}
-              <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
-                {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities) %}
-                <a href="{{ h.url_for(controller='user', action='dashboard_datasets') }}" title="{{ notifications_tooltip }}">
-                  <i class="fa fa-tachometer" aria-hidden="true"></i>
-                  <span class="text">{{ _('Dashboard') }}</span>
-                  <span class="badge">{{ new_activities }}</span>
-                </a>
-              </li>
-              {% block header_account_settings_link %}
-                <li>
-                  <a href="{{ h.url_for(controller='user', action='edit', id=c.userobj.name) }}" title="{{ _('Edit settings') }}">
-                    <i class="fa fa-cog" aria-hidden="true"></i>
-                    <span class="text">{{ _('Settings') }}</span>
-                  </a>
-                </li>
-              {% endblock %}
               {% block header_account_log_out_link %}
                 <li>
                   <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
@@ -88,11 +71,13 @@
                 <div class="rpl-menu__column">
                   <div class="rpl-menu__header"><!----> <!----></div>
                   <ul class="rpl-menu__items rpl-menu__items--root">
-                    {% if c.userobj %}
                     <li class="rpl-menu__item">
-                      <a href="{{ h.url_for(controller='user', action='dashboard_datasets') }}" class="rpl-link rpl-menu__item-link">{{ _('Dashboard') }}</a>
-                    </li>
+                    {% if c.userobj %}
+                      <a href="{{ h.url_for(controller='user', action='dashboard') }}" class="rpl-link rpl-menu__item-link">{{ _('Dashboard') }}</a>
+                    {% else %}
+                      <a href="{{ h.url_for(controller='user', action='login') }}" class="rpl-link rpl-menu__item-link">{{ _('Login') }}</a>
                     {% endif %}
+                    </li>
                     <li class="rpl-menu__item">
                       <a href="{{ h.url_for('search') }}" class="rpl-link rpl-menu__item-link">{{ _('Data') }}</a>
                     </li>
@@ -149,11 +134,13 @@
                     <!----> <!---->
                   </div>
                   <ul class="rpl-menu__items rpl-menu__items--root">
-                    {% if c.userobj %}
                     <li class="rpl-menu__item">
-                        <a href="{{ h.url_for(controller='user', action='dashboard_datasets') }}" class="rpl-link rpl-menu__item-link">{{ _('Dashboard') }}</a>
-                    </li>
+                    {% if c.userobj %}
+                        <a href="{{ h.url_for(controller='user', action='dashboard') }}" class="rpl-link rpl-menu__item-link">{{ _('Dashboard') }}</a>
+                    {% else %}
+                      <a href="{{ h.url_for(controller='user', action='login') }}" class="rpl-link rpl-menu__item-link">{{ _('Login') }}</a>
                     {% endif %}
+                    </li>
                     <li class="rpl-menu__item">
                       <a href="{{ h.url_for('search') }}" class="rpl-link rpl-menu__item-link">{{ _('Datasets') }}</a>
                     </li>

--- a/ckanext/datavic_iar_theme/templates/user/dashboard.html
+++ b/ckanext/datavic_iar_theme/templates/user/dashboard.html
@@ -6,10 +6,12 @@
           {% link_for _('Edit settings'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}
         </div>
         <ul class="nav nav-tabs">
-          {{ h.build_nav_icon('user_dashboard_datasets', _('My datasets')) }}
+          <li class="{% if h.current_url () == '/dashboard' %}active{% endif %}">
+            <a href="/dashboard"><i class="fa fa-sitemap"></i> My datasets</a>
+          </li>
           {{ h.build_nav_icon('user_dashboard_organizations', _('My organizations')) }}
           {{ h.build_nav_icon('user_dashboard_groups', _('My groups')) }}
-          {{ h.build_nav_icon('user_dashboard', _('News feed')) }}
+          {{ h.build_nav_icon('user_dashboard_newsfeed', _('News feed')) }}
           {% if h.check_access('user_dashboard_reports') %}
             {{ h.build_nav_icon('user_dashboard_reports', _('Reports')) }}
           {% endif %}

--- a/ckanext/datavic_iar_theme/templates/user/snippets/login_form.html
+++ b/ckanext/datavic_iar_theme/templates/user/snippets/login_form.html
@@ -14,7 +14,7 @@ Example:
 {% set username_error = true if error_summary %}
 {% set password_error = true if error_summary %}
 
-<form action="{{ action }}?came_from=/dashboard/datasets" method="post" class="form-horizontal">
+<form action="{{ action }}" method="post" class="form-horizontal">
   {{ form.errors(errors=error_summary) }}
 
   {{ form.input('login', label=_("Username"), id='field-login', value="", error=username_error, classes=["control-medium"]) }}


### PR DESCRIPTION
…` parameter.

This PR applies front-end changes to resolve the issue where the login error message wasn't being displayed.

While I was in there, I made the changes related to DATAVIC-174 (i.e. adding Login link to primary nav and removing the dashboard and edit settings buttons from the top user nav)