### PR TITLE
Locking CKAN edit functions of any records supplied through external harvests of catalogues

### DIFF
--- a/ckanext/datavic_iar_theme/templates/package/read_base.html
+++ b/ckanext/datavic_iar_theme/templates/package/read_base.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% block content_action %}
+  {% if h.is_dataset_harvested(pkg.id) %}
+    {% set harvest_text = 'Harvest Data' if h.check_access('sysadmin') else 'Harvest Data - Read Only'%}
+    {% set harvest_icon = 'unlock' if h.check_access('sysadmin') else 'lock'%}
+    {% set harvest_title = 'This dataset has been harvested and should only be updated from the harvested source' if h.check_access('sysadmin') else 'This dataset has been harvested and can only be updated from the harvested source'%}
+    <span class="label label-inverse" title="{{ harvest_title }}" >
+      <i class="fa fa-{{ harvest_icon }}"></i>
+      {{ harvest_text }}
+    </span>
+  {% endif %}
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    {% link_for _('Manage'), controller='package', action='edit', id=pkg.name, class_='btn', icon='wrench' %}   
+  {% endif %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/package/snippets/package_form.html
+++ b/ckanext/datavic_iar_theme/templates/package/snippets/package_form.html
@@ -1,0 +1,19 @@
+{% ckan_extends %}
+
+{% set form_style = c.form_style or c.action %}
+{% set is_dataset_harvested =  h.is_dataset_harvested(c.pkg_dict.id) %}
+{% set confirmation_text =  _('This dataset has been harvested and should only be updated from the harvested source. ') if is_dataset_harvested else '' %}
+
+{% block delete_button %}
+  {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
+    <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ confirmation_text }}{{ _('Are you sure you want to delete this dataset?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+  {% endif %}
+{% endblock %}
+
+{% block save_button %}
+  {% if form_style == 'edit' and is_dataset_harvested %}
+    <button class="btn btn-primary" type="submit" name="save" data-module="confirm-action" data-module-content="{{ confirmation_text }}{{ _('Are you sure you want to update?') }}">{{ _('Update Dataset') }}</button>
+  {% else %} 
+    <button class="btn btn-primary" type="submit" name="save" >{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+  {% endif %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/package/snippets/resource_form.html
+++ b/ckanext/datavic_iar_theme/templates/package/snippets/resource_form.html
@@ -1,0 +1,24 @@
+{% ckan_extends %}
+
+{% set data = data or {} %}
+{% set errors = errors or {} %}
+{% set action = form_action or h.url_for(controller='package', action='new_resource', id=pkg_name) %}
+{% set is_dataset_harvested =  h.is_dataset_harvested(data.package_id) %}
+{% set confirmation_text =  _('This resource has been harvested and should only be updated from the harvested source. ') if is_dataset_harvested else '' %}
+
+{% block delete_button %}
+  {% if data.id %}
+    {% if h.check_access('resource_delete', {'id': data.id})  %}
+        <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='resource_delete', resource_id=data.id, id=pkg_name %}" data-module="confirm-action" data-module-content="{{ confirmation_text }}{{ _('Are you sure you want to delete this resource?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+    {% endif %}
+  {% endif %}
+{% endblock %}
+
+{% block save_button %}
+  {% if is_dataset_harvested %}
+    <button class="btn btn-primary" name="save" value="go-metadata" type="submit" data-module="confirm-action" data-module-content="{{ confirmation_text }}{{ _('Are you sure you want to update?') }}">{{ _('Update resource') }}</button>
+  {% else %} 
+    <button class="btn btn-primary" name="save" value="go-metadata" type="submit">{% block save_button_text %}{{ _('Finish') }}{% endblock %}</button>
+  {% endif %}
+{% endblock %}
+


### PR DESCRIPTION
https://digital-engagement.atlassian.net/browse/DATAVIC-189
Override package_update auth to only allow sysadmins to update datasets and resources for harvested data

Confirmation modules are displayed for updating/deleting harvested dataset/resources Harvest Data label shown instead of Manage button for non sysadmins for harvested datasets