### PR TITLE
Remove 'dashboard' option for MEMBER account holders in the Data Directory

### DIFF
--- a/ckanext/datavic_iar_theme/templates/header.html
+++ b/ckanext/datavic_iar_theme/templates/header.html
@@ -74,7 +74,9 @@
                   <ul class="rpl-menu__items rpl-menu__items--root">
                     <li class="rpl-menu__item">
                     {% if c.userobj %}
-                      <a href="{{ h.url_for(controller='user', action='dashboard') }}" class="rpl-link rpl-menu__item-link">{{ _('Dashboard') }}</a>
+                      {% if h.check_access('package_create') %}
+                        <a href="{{ h.url_for(controller='user', action='dashboard') }}" class="rpl-link rpl-menu__item-link">{{ _('Dashboard') }}</a>
+                      {% endif %}
                     {% else %}
                       <a href="{{ h.url_for(controller='user', action='login') }}" class="rpl-link rpl-menu__item-link">{{ _('Login') }}</a>
                     {% endif %}
@@ -134,7 +136,9 @@
                   <ul class="rpl-menu__items rpl-menu__items--root">
                     <li class="rpl-menu__item">
                     {% if c.userobj %}
+                      {% if h.check_access('package_create') %}
                         <a href="{{ h.url_for(controller='user', action='dashboard') }}" class="rpl-link rpl-menu__item-link">{{ _('Dashboard') }}</a>
+                      {% endif %}
                     {% else %}
                       <a href="{{ h.url_for(controller='user', action='login') }}" class="rpl-link rpl-menu__item-link">{{ _('Login') }}</a>
                     {% endif %}

--- a/ckanext/datavic_iar_theme/templates/user/dashboard.html
+++ b/ckanext/datavic_iar_theme/templates/user/dashboard.html
@@ -3,7 +3,7 @@
     {% block page_header %}
       <header class="dashboard module-content page-header hug">
         <div class="content_action">
-          {% link_for _('Manage'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}
+          {% link_for _('Edit'), controller='user', action='edit', id=user.name, class_='btn', icon='cog' %}
         </div>
         <ul class="nav nav-tabs">
           {% if h.check_access('package_create') %}

--- a/ckanext/datavic_iar_theme/templates/user/edit.html
+++ b/ckanext/datavic_iar_theme/templates/user/edit.html
@@ -4,5 +4,5 @@
   <li><a href="{{ h.url_for(controller='user', action='index') }}">{{ _('Users') }}</a></li>
   {% set user_url = h.url_for(controller='user', action='read', id=c.userobj.name) if h.check_access('package_create') else h.url_for(controller='user', action='activity', id=c.userobj.name) %}
   <li><a href="{{ user_url }}">{{ c.user_dict.display_name }}</a></li>
-  <li class="active"><a href="#">{{ _('Manage') }}</a></li>
+  <li class="active"><a href="#">{{ _('Edit') }}</a></li>
 {% endblock %}

--- a/ckanext/datavic_iar_theme/templates/user/edit_base.html
+++ b/ckanext/datavic_iar_theme/templates/user/edit_base.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+
+{% block subtitle %}{{ _('Edit') }} - {{ c.user_dict.display_name }} - {{ _('Users') }}{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/user/read_base.html
+++ b/ckanext/datavic_iar_theme/templates/user/read_base.html
@@ -9,6 +9,12 @@
   {% endif %} 
 {% endblock %}
 
+{% block content_action %}
+  {% if h.check_access('user_update', user) %}
+    {% link_for _('Edit'), controller='user', action='edit', id=user.name, class_='btn', icon='wrench' %}
+  {% endif %}
+{% endblock %}
+
 {% block content_primary_nav %}
   {% if h.check_access('package_create') %}
     {{ h.build_nav_icon('user_datasets', _('Datasets'), id=user.name) }}


### PR DESCRIPTION
https://digital-engagement.atlassian.net/browse/DATAVIC-210
Only show dashboard to editor, admin, sysadmin users
Update any 'Member' references in user templates to 'Edit'