### PR TITLE
Data.Vic (Search) - Unable to deselect Category field after making a search

### DIFF
--- a/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
@@ -98,7 +98,7 @@
                               <div class="rpl-checklist__main-row">
                                 <button type="button" class="rpl-checklist__info" data-checklist="checklist-group">
                                   {% if group %}
-                                    {% for item in h.group_list() %}
+                                    {% for item in h.search_form_group_list() %}
                                       {% if item.name == group %}
                                         <span>{{ item.display_name }}</span>
                                       {% endif %}


### PR DESCRIPTION
Fixed bug when category group was not selected in dropwdown after form submit