### PR TITLE
[DATAVIC-224] Hide create account on Login page

### DIFF
--- a/ckanext/datavic_iar_theme/templates/user/login.html
+++ b/ckanext/datavic_iar_theme/templates/user/login.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+<!-- Remove register create account section -->
+{% block help_register %}
+
+{% endblock %}


### PR DESCRIPTION
Added 'user/login' template override for removing register create account section