### PR TITLE
SXDEDPCXZIC-55_DATAVIC-459 / add alt for remember-me checkbox

### DIFF
--- a/ckanext/datavic_iar_theme/templates/user/snippets/login_form.html
+++ b/ckanext/datavic_iar_theme/templates/user/snippets/login_form.html
@@ -26,10 +26,10 @@ Example:
       <label class="rpl-checkbox">
         <input type="checkbox" id='field-remember' name="remember" checked=true, value="63072000" />
         <span class="rpl-checkbox__box rpl-checkbox__box--checked">
-          <img src="/assets/icons/rpl_icon_tick.svg" class="rpl-icon rpl-icon--tick rpl-icon--color_primary" style="width:11px;height:11px;" >     
+          <img src="/assets/icons/rpl_icon_tick.svg" class="rpl-icon rpl-icon--tick rpl-icon--color_primary" style="width:11px;height:11px;" alt="">
         </span>
         <span class="rpl-checkbox__inline-label">{{ _("Remember me") }}</span>
-      </label>      
+      </label>
     </div>
   </div>
 


### PR DESCRIPTION
Ensure the alternative text for each image is available or if the image does not convey content, the image may be given empty/null alternative text (alt=””). In this instance, the images may be considered decorative and can be given the empty/null alternative text.