### PR TITLE
Sxdedpcxzic 65 datavic 440 First level heading is missing [CKAN - Directory & Discover][dev]

### DIFF
--- a/ckanext/datavic_iar_theme/grunt/sass/_header.scss
+++ b/ckanext/datavic_iar_theme/grunt/sass/_header.scss
@@ -254,7 +254,6 @@ $rpl-site-header-logout-btn-icon-margin: 0 0 0 $rpl-space-2 !default;
 }
 
 .module .dashboard-header {
-  padding: 15px;
   font-size: 1.5em;
-  padding: 0px 15px 0px 15px;
+  padding: 0px 15px 0px 30px;
 }

--- a/ckanext/datavic_iar_theme/grunt/sass/_header.scss
+++ b/ckanext/datavic_iar_theme/grunt/sass/_header.scss
@@ -252,3 +252,9 @@ $rpl-site-header-logout-btn-icon-margin: 0 0 0 $rpl-space-2 !default;
     }
   }
 }
+
+.module .dashboard-header {
+  padding: 15px;
+  font-size: 1.5em;
+  padding: 0px 15px 0px 15px;
+}

--- a/ckanext/datavic_iar_theme/grunt/sass/_search_form.scss
+++ b/ckanext/datavic_iar_theme/grunt/sass/_search_form.scss
@@ -80,6 +80,7 @@ $rpl-search-form-search-text: $rpl-search-form-show-filters-ruleset !default;
     @include rpl_typography_ruleset($rpl-search-form-heading-ruleset);
     color: $rpl-search-form-heading-color;
     margin-top: 0;
+    padding-left: 25px;
 
     @at-root {
       #{$root}--dark h1 {

--- a/ckanext/datavic_iar_theme/templates/package/snippets/resources_list.html
+++ b/ckanext/datavic_iar_theme/templates/package/snippets/resources_list.html
@@ -1,0 +1,40 @@
+{# 
+  Renders a list of resources with icons and view links.
+  
+  resources - A list of resources to render
+  pkg - A package object that the resources belong to.
+  
+  Example:
+  
+    {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources %}
+  
+  #}
+  <section id="dataset-resources" class="resources">
+    {% if historical %}
+      <h2>{{ _('Historical Data and Resources') }}</h2>
+    {% else %}
+      <h2>{{ _('Data and Resources') }}</h2>
+    {% endif %}
+  
+    {% block resource_list %}
+      {% if resources %}
+        <ul class="{% block resource_list_class %}resource-list{% endblock %}">
+          {% block resource_list_inner %}
+            {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+            {% for resource in resources %}
+              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit, historical=historical %}
+            {% endfor %}
+          {% endblock %}
+        </ul>
+      {% else %}
+        {% if h.check_access('resource_create', pkg) %}
+            {% trans url=h.url_for(controller='dataset', action='new_resource', id=pkg.name) %}
+              <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+            {% endtrans %}
+        {% else %}
+            <p class="empty">{{ _('This dataset has no data') }}</p>
+        {% endif %}
+      {% endif %}
+  
+    {% endblock %}
+  </section>

--- a/ckanext/datavic_iar_theme/templates/package/snippets/resources_list.html
+++ b/ckanext/datavic_iar_theme/templates/package/snippets/resources_list.html
@@ -1,8 +1,9 @@
-{# 
+{#
   Renders a list of resources with icons and view links.
   
-  resources - A list of resources to render
-  pkg - A package object that the resources belong to.
+  resources - A list of resources (dicts) to render
+  pkg - A package dict that the resources belong to.
+  is_activity_archive - Whether this is an old version of the dataset (and therefore read-only)
   
   Example:
   
@@ -15,26 +16,25 @@
     {% else %}
       <h2>{{ _('Data and Resources') }}</h2>
     {% endif %}
-  
     {% block resource_list %}
       {% if resources %}
         <ul class="{% block resource_list_class %}resource-list{% endblock %}">
           {% block resource_list_inner %}
-            {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+            {% set can_edit = h.check_access('package_update', {'id':pkg.id }) and not is_activity_archive %}
             {% for resource in resources %}
-              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit, historical=historical %}
+              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit, is_activity_archive=is_activity_archive %}
             {% endfor %}
           {% endblock %}
         </ul>
       {% else %}
-        {% if h.check_access('resource_create', pkg) %}
-            {% trans url=h.url_for(controller='dataset', action='new_resource', id=pkg.name) %}
+        {% if h.check_access('resource_create', {'package_id': pkg['id']}) and not is_activity_archive %}
+            {% trans url=h.url_for(pkg.type ~ '_resource.new', id=pkg.name) %}
               <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
             {% endtrans %}
         {% else %}
             <p class="empty">{{ _('This dataset has no data') }}</p>
         {% endif %}
       {% endif %}
-  
-    {% endblock %}
+      {% endblock %}
   </section>
+  

--- a/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
@@ -362,9 +362,7 @@
   {% endblock %}
 
   {% block search_title %}
-    {% if not error and count %}
-      <h2 class="block-search-title">{% snippet 'snippets/search_result_text.html', query=query, count=count, type=type %}</h2>
-    {% elif error %}
+    {% if error %}
       <h2>Error</h2>
     {% endif %}
   {% endblock %}

--- a/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
@@ -11,19 +11,20 @@
     <div class="search-form-wrapper">
       <div class="rpl-search-form da-search rpl-site-constrain--on-all">
         {% if query %}
-          <h1> {{ _('Search Results') }} ({{count}} 
-              {% if count == 1%} 
-                {{ _('dataset found') }} 
-              {% else %}
-                {{ _('datasets found') }}) 
-              {% endif %}</h1>
+          <h1> {{ ungettext(
+            'Search Results ({number} dataset found)', 
+            'Search Results ({number} datasets found)', 
+             count
+            ).format(number=count) }}
+         </h1>              
         {% else %}
-          <h1>{{ _('Search') }} {{count}} 
-            {% if count == 1%}  
-              {{ _('open dataset') }} 
-            {% else %} 
-              {{ _('open datasets') }} 
-            {% endif %}</h1>
+          <h1>
+            {{ ungettext(
+              'Search {number} open dataset', 
+              'Search {number} open datasets', 
+               count
+            ).format(number=count) }}
+         </h1>
         {% endif %}
         <form {% if form_id %}id="{{ form_id }}" {% endif %}class="rpl-form" action="{{ h.url_for('dataset.search') }}" method="get">
           <input type="hidden" id="field-order-by" name="sort" value="{{ sorting_selected }}" />

--- a/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
@@ -11,9 +11,9 @@
     <div class="search-form-wrapper">
       <div class="rpl-search-form da-search rpl-site-constrain--on-all">
         {% if query %}
-        <h1>Search Results ({{count}} datasets found) </h1>
+          <h1>Search Results ({{count}} datasets found) </h1>
         {% else %}
-        <h1>Search {{count}} open datasets </h1>
+          <h1>Search {{count}} open datasets </h1>
         {% endif %}
         <form {% if form_id %}id="{{ form_id }}" {% endif %}class="rpl-form" action="{{ h.url_for('dataset.search') }}" method="get">
           <input type="hidden" id="field-order-by" name="sort" value="{{ sorting_selected }}" />

--- a/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
@@ -10,6 +10,11 @@
 
     <div class="search-form-wrapper">
       <div class="rpl-search-form da-search rpl-site-constrain--on-all">
+        {% if query %}
+        <h1>Search Results ({{count}} datasets found) </h1>
+        {% else %}
+        <h1>Search {{count}} open datasets </h1>
+        {% endif %}
         <form {% if form_id %}id="{{ form_id }}" {% endif %}class="rpl-form" action="{{ h.url_for('dataset.search') }}" method="get">
           <input type="hidden" id="field-order-by" name="sort" value="{{ sorting_selected }}" />
           <input type="hidden" id="field-visibility" name="visibility" value="{{ visibility_selected }}" />

--- a/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_iar_theme/templates/snippets/dataset_search_form.html
@@ -11,9 +11,19 @@
     <div class="search-form-wrapper">
       <div class="rpl-search-form da-search rpl-site-constrain--on-all">
         {% if query %}
-          <h1>Search Results ({{count}} datasets found) </h1>
+          <h1> {{ _('Search Results') }} ({{count}} 
+              {% if count == 1%} 
+                {{ _('dataset found') }} 
+              {% else %}
+                {{ _('datasets found') }}) 
+              {% endif %}</h1>
         {% else %}
-          <h1>Search {{count}} open datasets </h1>
+          <h1>{{ _('Search') }} {{count}} 
+            {% if count == 1%}  
+              {{ _('open dataset') }} 
+            {% else %} 
+              {{ _('open datasets') }} 
+            {% endif %}</h1>
         {% endif %}
         <form {% if form_id %}id="{{ form_id }}" {% endif %}class="rpl-form" action="{{ h.url_for('dataset.search') }}" method="get">
           <input type="hidden" id="field-order-by" name="sort" value="{{ sorting_selected }}" />

--- a/ckanext/datavic_iar_theme/templates/user/dashboard.html
+++ b/ckanext/datavic_iar_theme/templates/user/dashboard.html
@@ -1,6 +1,7 @@
 {% ckan_extends %}
 
     {% block page_header %}
+      <h1 class="dashboard-header">{{ _('My Dashboard') }}</h1>
       <header class="module-content page-header hug">
         <div class="content_action">
           {% link_for _('Edit'), named_route='datavicuser.edit', id=user.name, class_='btn', icon='cog' %}

--- a/ckanext/datavic_iar_theme/webassets/datavic_iar_theme.css
+++ b/ckanext/datavic_iar_theme/webassets/datavic_iar_theme.css
@@ -1305,6 +1305,11 @@ nav {
     line-height: 1rem;
     padding-left: 0; }
 
+.module .dashboard-header {
+  padding: 15px;
+  font-size: 1.5em;
+  padding: 0px 15px 0px 15px; }
+
 .rpl-text-icon--before {
   margin: auto .5rem auto auto; }
 

--- a/ckanext/datavic_iar_theme/webassets/datavic_iar_theme.css
+++ b/ckanext/datavic_iar_theme/webassets/datavic_iar_theme.css
@@ -1306,9 +1306,8 @@ nav {
     padding-left: 0; }
 
 .module .dashboard-header {
-  padding: 15px;
   font-size: 1.5em;
-  padding: 0px 15px 0px 15px; }
+  padding: 0px 15px 0px 30px; }
 
 .rpl-text-icon--before {
   margin: auto .5rem auto auto; }
@@ -2297,7 +2296,8 @@ label.rpl-checkbox:after {
       padding-bottom: 3.75rem; } }
   .rpl-search-form h1 {
     color: #F6BE00;
-    margin-top: 0; }
+    margin-top: 0;
+    padding-left: 25px; }
     @media screen and (min-width: 0) {
       .rpl-search-form h1 {
         font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";


### PR DESCRIPTION
-  Updated dataset Search Results Page
- Remove this similar text underneath order by sorting function - X datasets found for ““ 
- updated  Data Record Page (Historical Tab)- 
- Add “My Dashboard“ as H1 to above the tabs. Text not too large to push down the rest of the page.