### PR TITLE
Release: 2.10.10 – Point of contact / custodian fields

### DIFF
--- a/ckanext/datavic_iar_theme/helpers.py
+++ b/ckanext/datavic_iar_theme/helpers.py
@@ -20,6 +20,9 @@ from ckanext.scheming.helpers import scheming_get_dataset_schema
 import ckanext.datavic_iar_theme.config as conf
 import ckanext.datavicmain.const as const
 
+from urllib.parse import urlparse
+from ckan.logic.validators import email_validator as ckan_email_validator
+from ckan.lib.navl.dictization_functions import Invalid
 
 log = logging.getLogger(__name__)
 helper, get_helpers = Collector("vic_iar").split()
@@ -521,3 +524,30 @@ def datavic_user_image(user_id: str, size: int = 100) -> Union[Markup, str]:
         )
     else:
         return ''
+
+
+@helper
+def is_url(value) -> bool:
+    if not value:
+        return False
+
+    try:
+        parsed = urlparse(value)
+        if parsed.scheme and parsed.netloc and parsed.scheme in ("http", "https"):
+            return True
+    except (ValueError, TypeError):
+        pass
+
+    return False
+
+
+@helper
+def is_email(value) -> bool:
+    if not value:
+        return False
+
+    try:
+        ckan_email_validator(value, {})
+        return True
+    except Invalid:
+        return False

--- a/ckanext/datavic_iar_theme/helpers.py
+++ b/ckanext/datavic_iar_theme/helpers.py
@@ -20,10 +20,6 @@ from ckanext.scheming.helpers import scheming_get_dataset_schema
 import ckanext.datavic_iar_theme.config as conf
 import ckanext.datavicmain.const as const
 
-from urllib.parse import urlparse
-from ckan.logic.validators import email_validator as ckan_email_validator
-from ckan.lib.navl.dictization_functions import Invalid
-
 log = logging.getLogger(__name__)
 helper, get_helpers = Collector("vic_iar").split()
 
@@ -527,27 +523,12 @@ def datavic_user_image(user_id: str, size: int = 100) -> Union[Markup, str]:
 
 
 @helper
-def is_url(value) -> bool:
-    if not value:
-        return False
-
-    try:
-        parsed = urlparse(value)
-        if parsed.scheme and parsed.netloc and parsed.scheme in ("http", "https"):
-            return True
-    except (ValueError, TypeError):
-        pass
-
-    return False
-
-
-@helper
 def is_email(value) -> bool:
     if not value:
         return False
 
     try:
-        ckan_email_validator(value, {})
+        tk.get_validator("email_validator")(value, {})
         return True
-    except Invalid:
+    except tk.Invalid:
         return False

--- a/ckanext/datavic_iar_theme/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/datavic_iar_theme/templates/scheming/package/snippets/additional_info.html
@@ -266,7 +266,7 @@
           <tr>
             <th scope="row" class="dataset-label">{{ _("Point of contact") }}</th>
             <td class="dataset-details">
-              {% if h.vic_iar_is_url(pkg_dict.contact_point) %}
+              {% if h.is_url(pkg_dict.contact_point) %}
                 <a href="{{ pkg_dict.contact_point }}" target="_blank" rel="nofollow">{{ pkg_dict.contact_point }}</a>
               {% elif h.vic_iar_is_email(pkg_dict.contact_point) %}
                 <a href="mailto:{{ pkg_dict.contact_point }}">{{ pkg_dict.contact_point }}</a>

--- a/ckanext/datavic_iar_theme/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/datavic_iar_theme/templates/scheming/package/snippets/additional_info.html
@@ -262,6 +262,21 @@
           </tr>
         {% endif %}
 
+        {% if pkg_dict.contact_point %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Point of contact") }}</th>
+            <td class="dataset-details">
+              {% if h.vic_iar_is_url(pkg_dict.contact_point) %}
+                <a href="{{ pkg_dict.contact_point }}" target="_blank" rel="nofollow">{{ pkg_dict.contact_point }}</a>
+              {% elif h.vic_iar_is_email(pkg_dict.contact_point) %}
+                <a href="mailto:{{ pkg_dict.contact_point }}">{{ pkg_dict.contact_point }}</a>
+              {% else %}
+                {{ pkg_dict.contact_point }}
+              {% endif %}
+            </td>
+          </tr>
+        {% endif %}
+
       {% block extras scoped %}
       {% endblock %}
 


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-949](https://digital-vic.atlassian.net/browse/DATAVIC-949) — Point of contact / custodian fields**
- `vic_iar_is_email` helper: validates values with CKAN `email_validator`
- `additional_info.html`: renders `contact_point` as Point of contact — mailto link for emails, external link for URLs, plain text otherwise

[DATAVIC-949]: https://digital-vic.atlassian.net/browse/DATAVIC-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ