### PR TITLE
Release: 2.10.11 – Remove DaAS items from DD nav

### DIFF
--- a/ckanext/datavic_iar_theme/helpers.py
+++ b/ckanext/datavic_iar_theme/helpers.py
@@ -308,19 +308,6 @@ def get_header_structure(userobj: model.User | None) -> list[dict[str, Any]]:
                 },
             ],
         },
-        {
-            "title": tk._("DaAS"),
-            "subtitle": tk._("""Digital and Analytics Service (DaAS)"""),
-            "url": "#",
-            "hide": not is_logged_in,
-            "child": [
-                {
-                    "title": page["title"],
-                    "url": _build_page_url(page),
-                }
-                for page in _get_daas_pages()
-            ],
-        },
     ]
 
 
@@ -340,26 +327,6 @@ def _get_page_item(name: str) -> dict[str, Any] | None:
         return None
 
     return result
-
-
-def _build_page_url(page: dict[str, Any]) -> str:
-    """Build a page URL for ckanext-pages entity based on the page type and name"""
-    page_type = "blog" if page["page_type"] == "blog" else conf.get_pages_base_url()
-
-    return f"/{page_type}/{page['name']}"
-
-
-def _get_daas_pages():
-    """Return a list of DaAS pages. Exclude pages that are not DaAS related,
-    but were created with ckanext-pages"""
-    exclude = ("user-guides", "contact-us", "data-sharing-resources")
-    result = tk.get_action("ckanext_pages_list")({}, {"order": True, "private": False})
-
-    return [
-        page
-        for page in result
-        if (page["page_type"] == "page" and page["name"] not in exclude)
-    ]
 
 
 @helper


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-981](https://digital-vic.atlassian.net/browse/DATAVIC-981) — Remove DaAS items from DD nav**

- Removed the `DaAS` entry and its child items from `get_header_structure()` in `ckanext/datavic_iar_theme/helpers.py`. Authenticated users now see only My account, Support, Data sharing, Datasets and Log Out in the primary nav.
- Deleted the now-unused `_get_daas_pages()` helper, which listed `ckanext-pages` pages of type `page` excluding `user-guides`, `contact-us` and `data-sharing-resources`.
- Deleted the now-unused `_build_page_url()` helper.


[DATAVIC-981]: https://digital-vic.atlassian.net/browse/DATAVIC-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ