### PR TITLE
[DATAVIC-983] updated email templates

### DIFF
--- a/ckanext/datavic_iar_theme/helpers.py
+++ b/ckanext/datavic_iar_theme/helpers.py
@@ -13,6 +13,7 @@ import ckan.model as model
 import ckan.plugins.toolkit as tk
 import ckan.lib.helpers as h
 
+from ckanext.auth import config as auth_config
 from ckanext.harvest.model import HarvestSource
 from ckanext.toolbelt.decorators import Collector, Cache
 from ckanext.scheming.helpers import scheming_get_dataset_schema
@@ -81,6 +82,17 @@ def format_list() -> list[str]:
 @helper
 def get_parent_site_url():
     return conf.get_parent_site_url().rstrip("/")
+
+
+@helper
+def get_2fa_email_interval_minutes() -> int:
+    """Return the 2FA email verification code TTL, in whole minutes.
+
+    Reads ``ckanext.auth.2fa_email_interval`` (seconds, default 600) so the
+    verification code email always reflects the configured expiry instead of
+    a hardcoded value.
+    """
+    return auth_config.get_2fa_email_interval() // 60
 
 
 @helper

--- a/ckanext/datavic_iar_theme/mailer.py
+++ b/ckanext/datavic_iar_theme/mailer.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import ckan.lib.mailer as ckan_mailer
+import ckan.plugins.toolkit as tk
+from ckan import model
+
+
+def _base_vars(user: model.User) -> dict[str, Any]:
+    return {
+        "reset_link": ckan_mailer.get_reset_link(user),
+        "site_title": tk.config.get("ckan.site_title"),
+        "site_url": tk.config.get("ckan.site_url"),
+        "user_name": user.name,
+    }
+
+
+def _subject(template: str, site_title: Optional[str]) -> str:
+    # First line only - guards against the {% trans %} trailing newline
+    # becoming a header-injection vector (matches core behaviour).
+    return tk.render(template, {"site_title": site_title}).split("\n")[0]
+
+
+def send_invite(
+    user: model.User,
+    group_dict: Optional[dict[str, Any]] = None,
+    role: Optional[str] = None,
+) -> None:
+    """As ckan.lib.mailer.send_invite, plus an HTML alternative.
+
+    Core's mail_user builds the multipart/alternative message and raises
+    MailerException on any SMTP failure, which is what user_invite catches
+    to roll back the pending user.
+    """
+    ckan_mailer.create_reset_key(user)
+    extra_vars = _base_vars(user)
+
+    if role:
+        extra_vars["role_name"] = tk.h.roles_translated().get(role, tk._(role))
+    if group_dict:
+        extra_vars["group_type"] = (
+            tk._("organization") if group_dict["is_organization"] else tk._("group")
+        )
+        extra_vars["group_title"] = group_dict.get("title")
+
+    ckan_mailer.mail_user(
+        user,
+        _subject("emails/invite_user_subject.txt", extra_vars["site_title"]),
+        tk.render("emails/invite_user.txt", extra_vars),
+        body_html=tk.render("emails/invite_user.html", extra_vars),
+    )

--- a/ckanext/datavic_iar_theme/mailer.py
+++ b/ckanext/datavic_iar_theme/mailer.py
@@ -36,14 +36,6 @@ def send_invite(
     ckan_mailer.create_reset_key(user)
     extra_vars = _base_vars(user)
 
-    if role:
-        extra_vars["role_name"] = tk.h.roles_translated().get(role, tk._(role))
-    if group_dict:
-        extra_vars["group_type"] = (
-            tk._("organization") if group_dict["is_organization"] else tk._("group")
-        )
-        extra_vars["group_title"] = group_dict.get("title")
-
     ckan_mailer.mail_user(
         user,
         _subject("emails/invite_user_subject.txt", extra_vars["site_title"]),

--- a/ckanext/datavic_iar_theme/plugin.py
+++ b/ckanext/datavic_iar_theme/plugin.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import ckan.lib.mailer as ckan_mailer
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 from ckan import types
+from ckanext.datavic_iar_theme.mailer import send_invite
+
 import ckanext.datavic_iar_theme.helpers as helpers
 
 from ckanext.search_autocomplete.interfaces import ISearchAutocomplete
@@ -33,6 +36,12 @@ class DatavicIARThemePlugin(p.SingletonPlugin):
         # Reset group/organization cache on server restart
         helpers.group_list.reset(is_organization=False)
         helpers.group_list.reset(is_organization=True)
+
+        # CKAN core's send_invite sends plain text only. Patch it to also
+        # send an HTML alternative. Acceptable here because core calls it as
+        # a module attribute (ckan/logic/action/create.py:1114), resolved at
+        # call time rather than bound at import. Re-verify on CKAN upgrade.
+        ckan_mailer.send_invite = send_invite
 
     # ITemplateHelpers
     def get_helpers(self):

--- a/ckanext/datavic_iar_theme/templates/auth/emails/verification_code.html
+++ b/ckanext/datavic_iar_theme/templates/auth/emails/verification_code.html
@@ -1,9 +1,11 @@
 {% extends "mailcraft/emails/base.html" %}
 {% block main_text %}
+  {% set expiry_minutes = h.vic_iar_get_2fa_email_interval_minutes() %}
+  {% set expiry_label = ungettext('{num} minute', '{num} minutes', expiry_minutes).format(num=expiry_minutes) %}
   {% trans %}
     <p>Hi {{ user_name }}</p>
     <p>Your verification code is <strong>{{ verification_code }}</strong>.</p>
-    <p>This one-time code expires in 10 minutes.</p>
+    <p>This one-time code expires in {{ expiry_label }}.</p>
     <p>If you did not request this, please <a href="mailto:datavic@dpc.vic.gov.au">contact us</a> immediately.</p>
   {% endtrans %}
 {% endblock %}

--- a/ckanext/datavic_iar_theme/templates/auth/emails/verification_code.html
+++ b/ckanext/datavic_iar_theme/templates/auth/emails/verification_code.html
@@ -2,7 +2,8 @@
 {% block main_text %}
   {% trans %}
     <p>Hi {{ user_name }}</p>
-    <p><a href="{{ reset_link }}">Reset your {{ site_title }} password here.</a></p>
+    <p>Your verification code is <strong>{{ verification_code }}</strong>.</p>
+    <p>This one-time code expires in 10 minutes.</p>
     <p>If you did not request this, please <a href="mailto:datavic@dpc.vic.gov.au">contact us</a> immediately.</p>
   {% endtrans %}
 {% endblock %}

--- a/ckanext/datavic_iar_theme/templates/email/notification-admin.html
+++ b/ckanext/datavic_iar_theme/templates/email/notification-admin.html
@@ -1,0 +1,16 @@
+{% extends "mailcraft/emails/base.html" %}
+{% block main_text %}
+    {% trans %}
+        <p>Hi {{ admin_user }}</p>
+        <p><a href="{{url}}">{{ package_name }}</a> requires your approval on the {{ site_title }}.<br/>Please review and action.</p>
+    {% endtrans %}
+
+    <p>
+        {% trans %}Submitted for approval by: {{user}}<br/>{% endtrans %}
+        {% trans %}Organisation: {{organization}}{% endtrans %}
+        {% if notes %}
+            <br/>
+            {% trans %}<span style="white-space: pre-line;">Notes: {{ notes }}</span>{% endtrans %}
+        {% endif %}
+    </p>
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/email/notification-admin.txt
+++ b/ckanext/datavic_iar_theme/templates/email/notification-admin.txt
@@ -1,6 +1,6 @@
 {% extends "mailcraft/emails/base.txt" %}
 {% block main_text %}
-{% trans %}Hi {{ admin_name }}{% endtrans %}
+{% trans %}Hi {{ admin_user }}{% endtrans %}
 
 {% trans %}{{ package_name }} ({{ url }}) requires your approval on the {{ site_title }}. Please review and action.{% endtrans %}
 

--- a/ckanext/datavic_iar_theme/templates/email/notification-admin.txt
+++ b/ckanext/datavic_iar_theme/templates/email/notification-admin.txt
@@ -1,0 +1,10 @@
+{% extends "mailcraft/emails/base.txt" %}
+{% block main_text %}
+{% trans %}Hi {{ admin_name }}{% endtrans %}
+
+{% trans %}{{ package_name }} ({{ url }}) requires your approval on the {{ site_title }}. Please review and action.{% endtrans %}
+
+{% trans %}Submitted for approval by: {{user}}{% endtrans %}
+{% trans %}Organisation: {{organization}}{% endtrans %}
+{% if notes %}{% trans %}Notes: {{ notes }}{% endtrans %}{% endif %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/email/notification-creator.html
+++ b/ckanext/datavic_iar_theme/templates/email/notification-creator.html
@@ -1,0 +1,14 @@
+{% extends "mailcraft/emails/base.html" %}
+{% block main_text %}
+    {% trans %}
+        <p>Hi {{name}}</p>
+
+        <p>Your dataset; <a href="{{ url }}">{{ package_name }}</a> has been returned to draft.</p>
+    {% endtrans %}
+
+    {% if notes %}
+        {% trans %}<p style="white-space: pre-line;">Notes: {{ notes }}</p>{% endtrans %}
+    {% endif %}
+
+    {% trans %}<p>Please review and action.</p>{% endtrans %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/email/notification-creator.txt
+++ b/ckanext/datavic_iar_theme/templates/email/notification-creator.txt
@@ -1,0 +1,10 @@
+{% extends "mailcraft/emails/base.txt" %}
+{% block main_text %}
+Hi {{name}},
+
+Your dataset; {{ package_name }} ({{ url }}) has been returned to draft.
+
+{% if notes %}{% trans %}Notes: {{ notes }}{% endtrans %}{% endif %}
+
+Please review and action.
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/emails/contact_form.html
+++ b/ckanext/datavic_iar_theme/templates/emails/contact_form.html
@@ -1,0 +1,15 @@
+{% extends "mailcraft/emails/base.html" %}
+{% block main_text %}
+  {% trans %}
+    <p>Hi</p>
+
+    <p>
+      {{ name }} has a query about <a href="{{ pkg_url }}">{{ pkg_name }}</a>:<br/>
+      <span style="white-space: pre-line;">{{ message }}</span>
+    </p>
+
+    <p>
+      Please respond to <a href="mailto:{{ email }}">{{ email }}</a>
+    </p>
+  {% endtrans %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/emails/contact_form.txt
+++ b/ckanext/datavic_iar_theme/templates/emails/contact_form.txt
@@ -1,0 +1,9 @@
+{% extends "mailcraft/emails/base.txt" %}
+{% block main_text %}
+{% trans %}Hi{% endtrans %}
+
+{% trans %}{{ name }} has a query about {{ pkg_name }} ({{ pkg_url }}):{% endtrans %}
+{% trans %}{{ message }}{% endtrans %}
+
+{% trans %}Please respond to {{ email }}{% endtrans %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/emails/contact_form.txt
+++ b/ckanext/datavic_iar_theme/templates/emails/contact_form.txt
@@ -2,8 +2,8 @@
 {% block main_text %}
 {% trans %}Hi{% endtrans %}
 
-{% trans %}{{ name }} has a query about {{ pkg_name }} ({{ pkg_url }}):{% endtrans %}
-{% trans %}{{ message }}{% endtrans %}
+{% trans safe_name=name|safe %}{{ safe_name }} has a query about {{ pkg_name }} ({{ pkg_url }}):{% endtrans %}
+{% trans safe_message=message | safe %}{{ safe_message }}{% endtrans %}
 
 {% trans %}Please respond to {{ email }}{% endtrans %}
 {% endblock %}

--- a/ckanext/datavic_iar_theme/templates/emails/invite_user.html
+++ b/ckanext/datavic_iar_theme/templates/emails/invite_user.html
@@ -1,0 +1,12 @@
+{% extends "mailcraft/emails/base.html" %}
+{% block main_text %}
+  {% trans %}
+    <p>Hi</p>
+    <p>You've been invited to join the {{ site_title }}.</p>
+    <p>Your username is {{ user_name }}.<br/>To activate your account, please <a href="{{ reset_link }}">set your password</a>.</p>
+    <p>The {{ site_title }} is an internal metadata catalogue where you can discover open, and restricted, Victorian Government datasets.</p>
+    <p>You can also register your department or agency's metadata and, where appropriate, publish to DataVic. <a href="https://www.data.vic.gov.au/data-publishing-victorian-public-service">Learn more about data publishing for the Victorian Public Service.</a></p>
+    <p>Access to the {{ site_title }} is restricted to the Victorian Public Service.</p>
+    <p>If you require any assistance, please <a href="mailto:datavic@dpc.vic.gov.au">contact us</a>.</p>
+  {% endtrans %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/emails/invite_user.txt
+++ b/ckanext/datavic_iar_theme/templates/emails/invite_user.txt
@@ -1,26 +1,18 @@
-{% set first_name = user_name.split("-")[0] %}Dear {{ first_name[0]|upper }}{{ first_name[1:] }},
-{% if role_name == 'Member' %}
-You have been invited to the {{ site_title }}. The {{ site_title }} is the place for Victoria Public Servants to find, discover and share data amongst departments and agencies.
+{% extends "mailcraft/emails/base.txt" %}
+{% block main_text %}
+{% trans %}Hi{% endtrans %}
 
-This is a new service that we are currently testing with a limited number of users. Your feedback will help us improve it.
+{% trans %}You've been invited to join the {{ site_title }}.{% endtrans %}
 
-An account has already been created for you with the username {{ user_name }}. You can change it later.
 
-Your account allows you to search and find open data as well as a data restricted to Victorian Public Servants.
-{% else %}
-You have been invited to the {{ site_title }}.
+{% trans %}Your username is {{ user_name }}.{% endtrans %}
+{% trans %}To activate your account, please set your password here: {{ reset_link }}{% endtrans %}
 
-A user has already been created for you with the username {{ user_name }}. You can change it later.
+{% trans %}The {{ site_title }} is an internal metadata catalogue where you can discover open, and restricted, Victorian Government datasets.{% endtrans %}
 
-You have been added to the {{ group_type }} {{ group_title }} with the following role: {{ role_name }}.
-{% endif %}
-To accept this invite, please reset your password at:
+{% trans %}You can also register your department or agency's metadata and, where appropriate, publish to DataVic. Learn more about data publishing for the Victorian Public Service here: https://www.data.vic.gov.au/data-publishing-victorian-public-service{% endtrans %}
 
-   {{ reset_link }}
+{% trans %}Access to the {{ site_title }} is restricted to the Victorian Public Service.{% endtrans %}
 
-Thankyou.
-
-The DataVic Team
-
---
-Message sent by the {{ site_title }} ({{ site_url }})
+{% trans %}If you require any assistance, please contact us at datavic@dpc.vic.gov.au.{% endtrans %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/emails/invite_user_subject.txt
+++ b/ckanext/datavic_iar_theme/templates/emails/invite_user_subject.txt
@@ -1,1 +1,1 @@
-Invitation to join and use the {{ site_title }}
+{% trans %}Invitation to join the {{ site_title }}{% endtrans %}

--- a/ckanext/datavic_iar_theme/templates/mailcraft/emails/base.html
+++ b/ckanext/datavic_iar_theme/templates/mailcraft/emails/base.html
@@ -46,6 +46,19 @@
         line-height:0;
         mso-hide:all;
       }
+
+      .es-wrapper-color {
+        font-size: 16px;
+      }
+
+      .es-wrapper-color a {
+        color: #206b82 !important;
+      }
+
+      .es-wrapper-color a:hover {
+        text-decoration: none !important;
+      }
+
       @media only screen and (max-width:600px) {p, ul li, ol li, a { line-height:150%!important } h1, h2, h3, h1 a, h2 a, h3 a { line-height:120%!important } h1 { font-size:30px!important; text-align:left } h2 { font-size:24px!important; text-align:left } h3 { font-size:20px!important; text-align:left } .es-header-body h1 a, .es-content-body h1 a, .es-footer-body h1 a { font-size:30px!important; text-align:left } .es-header-body h2 a, .es-content-body h2 a, .es-footer-body h2 a { font-size:24px!important; text-align:left } .es-header-body h3 a, .es-content-body h3 a, .es-footer-body h3 a { font-size:20px!important; text-align:left } .es-menu td a { font-size:14px!important } .es-header-body p, .es-header-body ul li, .es-header-body ol li, .es-header-body a { font-size:14px!important } .es-content-body p, .es-content-body ul li, .es-content-body ol li, .es-content-body a { font-size:14px!important } .es-footer-body p, .es-footer-body ul li, .es-footer-body ol li, .es-footer-body a { font-size:14px!important } .es-infoblock p, .es-infoblock ul li, .es-infoblock ol li, .es-infoblock a { font-size:12px!important } *[class="gmail-fix"] { display:none!important } .es-m-txt-c, .es-m-txt-c h1, .es-m-txt-c h2, .es-m-txt-c h3 { text-align:center!important } .es-m-txt-r, .es-m-txt-r h1, .es-m-txt-r h2, .es-m-txt-r h3 { text-align:right!important } .es-m-txt-l, .es-m-txt-l h1, .es-m-txt-l h2, .es-m-txt-l h3 { text-align:left!important } .es-m-txt-r img, .es-m-txt-c img, .es-m-txt-l img { display:inline!important } .es-button-border { display:inline-block!important } a.es-button, button.es-button { font-size:18px!important; display:inline-block!important } .es-adaptive table, .es-left, .es-right { width:100%!important } .es-content table, .es-header table, .es-footer table, .es-content, .es-footer, .es-header { width:100%!important; max-width:600px!important } .es-adapt-td { display:block!important; width:100%!important } .adapt-img { width:100%!important; height:auto!important } .es-m-p0 { padding:0px!important } .es-m-p0r { padding-right:0px!important } .es-m-p0l { padding-left:0px!important } .es-m-p0t { padding-top:0px!important } .es-m-p0b { padding-bottom:0!important } .es-m-p20b { padding-bottom:20px!important } .es-mobile-hidden, .es-hidden { display:none!important } tr.es-desk-hidden, td.es-desk-hidden, table.es-desk-hidden { width:auto!important; overflow:visible!important; float:none!important; max-height:inherit!important; line-height:inherit!important } tr.es-desk-hidden { display:table-row!important } table.es-desk-hidden { display:table!important } td.es-desk-menu-hidden { display:table-cell!important } .es-menu td { width:1%!important } table.es-table-not-adapt, .esd-block-html table { width:auto!important } table.es-social { display:inline-block!important } table.es-social td { display:inline-block!important } .es-desk-hidden { display:table-row!important; width:auto!important; overflow:visible!important; max-height:inherit!important } }
       @media screen and (max-width:384px) {.mail-message-content { width:414px!important } }
     </style>
@@ -136,10 +149,8 @@
                           <td align="left" style="padding:0;Margin:0;padding-bottom:20px">
                             {% block main_text %}{% endblock %}
                             {% block regards %}
-                              <p>
-                                Message sent by {{ site_title }} (<a href="{{ site_url }}">{{ site_url }}</a>)
-                              </p>
-                            {% endblock %}
+                              {% trans %}<p>Regards,<br/>{{ site_title }}</p>{% endtrans %}
+                            {% endblock %} 
                           </td>
                         </tr>
                       </table></td>

--- a/ckanext/datavic_iar_theme/templates/mailcraft/emails/base.txt
+++ b/ckanext/datavic_iar_theme/templates/mailcraft/emails/base.txt
@@ -1,0 +1,5 @@
+{% block main_text %}{% endblock %}
+{% block regards %}
+{% trans %}Regards,{% endtrans %}
+{% trans %}{{ site_title }}{% endtrans %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/mailcraft/emails/reset_password/body.txt
+++ b/ckanext/datavic_iar_theme/templates/mailcraft/emails/reset_password/body.txt
@@ -1,12 +1,8 @@
-{% trans %}
-Dear {{ user_name }},
+{% extends "mailcraft/emails/base.txt" %}
+{% block main_text %}
+{% trans %}Hi {{ user_name }}{% endtrans %}
 
-You have requested your password on {{ site_title }} to be reset.
+{% trans %}Reset your {{ site_title }} password here: {{ reset_link }}{% endtrans %}
 
-Please click the following link to confirm this request:
-
-   {{ reset_link }}
-
---
-Message sent by {{ site_title }} ({{ site_url }})
-{% endtrans %}
+{% trans %}If you did not request this, please contact us at datavic@dpc.vic.gov.au immediately.{% endtrans %}
+{% endblock %}

--- a/ckanext/datavic_iar_theme/templates/package/contact.html
+++ b/ckanext/datavic_iar_theme/templates/package/contact.html
@@ -15,7 +15,7 @@
             {% set email = data.email|lower if data else userobj.email|lower %}
             {{ form.input("email", label=_("Email"), id="field-email", value=email, error=errors.email, classes=["form-group"], is_required=true, attrs={"class": "form-control"}) }}
 
-            {% set subject = _("VPS Data Directory user query - ") + h.vic_iar_get_package_title(pkg_id) %}
+            {% set subject = _("User user about ") + h.vic_iar_get_package_title(pkg_id) %}
             {{ form.input("subject", label=_("Subject"), id="field-subject", value=subject, error=errors.subject, classes=["form-group subject-group"], is_required=true, attrs={"class": "form-control"}) }}
 
             {{ form.textarea("message", label=_("Message"), id="field-message", value=data.message, error=errors.message, classes=["form-group"], is_required=true, attrs={"class": "form-control"}) }}

--- a/ckanext/datavic_iar_theme/templates/package/contact.html
+++ b/ckanext/datavic_iar_theme/templates/package/contact.html
@@ -15,7 +15,7 @@
             {% set email = data.email|lower if data else userobj.email|lower %}
             {{ form.input("email", label=_("Email"), id="field-email", value=email, error=errors.email, classes=["form-group"], is_required=true, attrs={"class": "form-control"}) }}
 
-            {% set subject = _("User user about ") + h.vic_iar_get_package_title(pkg_id) %}
+            {% set subject = _("User query about ") + h.vic_iar_get_package_title(pkg_id) %}
             {{ form.input("subject", label=_("Subject"), id="field-subject", value=subject, error=errors.subject, classes=["form-group subject-group"], is_required=true, attrs={"class": "form-control"}) }}
 
             {{ form.textarea("message", label=_("Message"), id="field-message", value=data.message, error=errors.message, classes=["form-group"], is_required=true, attrs={"class": "form-control"}) }}


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-993

Changes
- added overwrite for `send_invite` only, as the `send_reset_link` is handled by mailcraft already
- styling

Notes
There are other extensions that has PR to add the email template supports.
- https://github.com/dpc-sdp/ckanext-workflow/pull/51
- https://github.com/dpc-sdp/ckanext-datasetform/pull/25
